### PR TITLE
feat(workflow): daed-pick-build workflow implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intro
 
-TBD.
+A serverless functions for internal interaction with [@daeuniverse](https://github.com/daeuniverse).
 
 ## Prerequisites
 
@@ -20,9 +20,10 @@ go run main.go
 
 ## API Comsumption
 
-- healthcheck - `/GET localhost:3000/api/v2/health`
-- fetch geodata(geosite.dat) - `/GET localhost:3000/api/v2/geodata?file=geosite.dat`
-- fetch geodata(geoip.dat) - `/GET localhost:3000/api/v2/geodata?file=geoip.dat`
+- healthcheck - `/GET localhost:5888/api/v2/health`
+- fetch geodata(geosite.dat) - `/GET localhost:5888/api/v2/geodata?file=geosite.dat`
+- fetch geodata(geoip.dat) - `/GET localhost:5888/api/v2/geodata?file=geoip.dat`
+- trigger daed-pick-build - `/POST localhost:5888/api/v2/workflow?name=daed-pick-build&daed=main&wing=origin/main&dae=origin/main`
 
 ## References
 

--- a/api/v2/workflow.go
+++ b/api/v2/workflow.go
@@ -1,10 +1,17 @@
 package v2
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"daeuniverse/functions/service"
 )
+
+type response struct {
+	Result       string `json:"result"`
+	WorkflowURL  string `json:"workflow_url"`
+	WorkflowFile string `json:"workflow_file"`
+}
 
 func WorkflowHandler(w http.ResponseWriter, r *http.Request) {
 	workflow := r.URL.Query().Get("name")
@@ -30,7 +37,8 @@ func WorkflowHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"result": "ok!"}`))
+		res := &response{Result: "ok!", WorkflowURL: "https://github.com/daeuniverse/daed/actions/workflows/pick-build.yml", WorkflowFile: "https://github.com/daeuniverse/daed/blob/main/.github/workflows/pick-build.yml"}
+		_ = json.NewEncoder(w).Encode(res)
 	} else {
 		w.WriteHeader(http.StatusNotAcceptable)
 		_, _ = w.Write([]byte(`{"error": "the given workflow cannot be trigger as it is not an available option."}`))

--- a/api/v2/workflow.go
+++ b/api/v2/workflow.go
@@ -1,0 +1,39 @@
+package v2
+
+import (
+	"net/http"
+
+	"daeuniverse/functions/service"
+)
+
+func WorkflowHandler(w http.ResponseWriter, r *http.Request) {
+	workflow := r.URL.Query().Get("name")
+	w.Header().Set("Content-Type", "application/json")
+
+	if workflow == "daed-pick-build" {
+		svc, err := service.NewFunctionService(
+			service.WithGithub("daeuniverse", "daed"),
+		)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		err = svc.TriggerPickBuild(
+			r.URL.Query().Get("daed"),
+			r.URL.Query().Get("wing"),
+			r.URL.Query().Get("dae"),
+		)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result": "ok!"}`))
+	} else {
+		w.WriteHeader(http.StatusNotAcceptable)
+		_, _ = w.Write([]byte(`{"error": "the given workflow cannot be trigger as it is not an available option."}`))
+
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 )
 
 func main() {
-	log.Printf("Server listening on port: %d", 3000)
+	log.Printf("Server listening on port: %d", 5888)
 	router := server.NewRouter()
-	err := router.Serve(3000)
+	err := router.Serve(5888)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -9,8 +9,9 @@ import (
 	"golang.org/x/oauth2"
 )
 
-type Repo interface {
+type Session interface {
 	GetLatestRelease() (*github.RepositoryRelease, error)
+	TriggerPickBuild(daedRef string, wingRef string, daeRef string) (*github.Response, error)
 	FormURL(releaseDate string, filetype string) string
 }
 
@@ -21,11 +22,13 @@ type session struct {
 	Repository   string
 }
 
+type Response = github.Response
+
 func (s *session) FormURL(releaseDate string, filetype string) string {
 	return fmt.Sprintf("https://github.com/%s/%s/releases/download/%s/%s", s.Organization, s.Repository, releaseDate, filetype)
 }
 
-func NewSession(organization string, repo string) Repo {
+func NewSession(organization string, repo string) Session {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestGithub_Auth(t *testing.T) {
-	repo := NewSession("techprober", "v2ray-rules-dat")
-	result, err := repo.GetLatestRelease()
+	client := NewSession("techprober", "v2ray-rules-dat")
+	result, err := client.GetLatestRelease()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	releaseDate := result.GetName()
-	url := repo.FormURL(releaseDate, "geosite.data")
+	url := client.FormURL(releaseDate, "geosite.data")
 
 	w := web.NewClient()
 	res, err := w.GetAndSave(url, "geosite.dat")
@@ -23,4 +23,13 @@ func TestGithub_Auth(t *testing.T) {
 	}
 
 	println(res.StatusCode())
+}
+
+func TestWorkflow_TriggerDaedPickBuild(t *testing.T) {
+	client := NewSession("daeuniverse", "daed")
+	result, err := client.TriggerPickBuild("main", "origin/main", "origin/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	println(result.StatusCode)
 }

--- a/pkg/github/workflow.go
+++ b/pkg/github/workflow.go
@@ -1,0 +1,21 @@
+package github
+
+import (
+	"github.com/google/go-github/v52/github"
+)
+
+const (
+	pickBuildWorkflowFile = "pick-build.yml"
+)
+
+func (s *session) TriggerPickBuild(daedRef string, wingRef string, daeRef string) (*github.Response, error) {
+	triggerReq := &github.CreateWorkflowDispatchEventRequest{
+		Ref:    "main",
+		Inputs: map[string]interface{}{"daed": daedRef, "wing": wingRef, "dae-core": daeRef},
+	}
+	result, err := s.Client.Actions.CreateWorkflowDispatchEventByFileName(s.Context, s.Organization, s.Repository, pickBuildWorkflowFile, *triggerReq)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/web/server/router.go
+++ b/pkg/web/server/router.go
@@ -48,6 +48,7 @@ func NewRouter() *Router {
 		Route{"GET", "/api/v2/geodata", api.GeodataHandler},
 		Route{"GET", "/api/v2/health", api.HealthcheckHandler},
 		Route{"GET", "/api/v2/index", api.IndexHandler},
+		Route{"POST", "/api/v2/workflow", api.WorkflowHandler},
 	})
 	return router
 }

--- a/service/service.go
+++ b/service/service.go
@@ -8,8 +8,8 @@ import (
 type FunctionConfiguration func(fs *FunctionService) error
 
 type FunctionService struct {
-	repo github.Repo
-	web  web.Client
+	session github.Session
+	web     web.Client
 }
 
 func NewFunctionService(cfgs ...FunctionConfiguration) (*FunctionService, error) {
@@ -25,7 +25,7 @@ func NewFunctionService(cfgs ...FunctionConfiguration) (*FunctionService, error)
 
 func WithGithub(organization string, repo string) FunctionConfiguration {
 	return func(s *FunctionService) error {
-		s.repo = github.NewSession(organization, repo)
+		s.session = github.NewSession(organization, repo)
 		return nil
 	}
 }
@@ -38,13 +38,13 @@ func WithWebClient() FunctionConfiguration {
 }
 
 func (s *FunctionService) FetchGeoData(filetype string) (*web.Response, error) {
-	release, err := s.repo.GetLatestRelease()
+	release, err := s.session.GetLatestRelease()
 	releaseDate := release.GetName()
 	if err != nil {
 		return nil, err
 	}
 
-	url := s.repo.FormURL(releaseDate, filetype)
+	url := s.session.FormURL(releaseDate, filetype)
 
 	res, err := s.web.Get(url)
 	if err != nil {
@@ -55,13 +55,21 @@ func (s *FunctionService) FetchGeoData(filetype string) (*web.Response, error) {
 }
 
 func (s *FunctionService) GetLatestGeodataReleaseURL(filetype string) (string, error) {
-	release, err := s.repo.GetLatestRelease()
+	release, err := s.session.GetLatestRelease()
 	releaseDate := release.GetName()
 	if err != nil {
 		return "", err
 	}
 
-	url := s.repo.FormURL(releaseDate, filetype)
+	url := s.session.FormURL(releaseDate, filetype)
 
 	return url, nil
+}
+
+func (s *FunctionService) TriggerPickBuild(daedRef string, wingRef string, daeRef string) error {
+	_, err := s.session.TriggerPickBuild(daedRef, wingRef, daeRef)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Background

Allow users to trigger [daed-pick-build](https://github.com/daeuniverse/daed/actions/workflows/pick-build.yml).

## Changelogs

- docs: add api consumption notes
- feat(workflow): daed-pick-build workflow implementation
- feat: api implementation for daed-pick-build workflow trigger
- patch: use 5888 as default port
- feat(api/workflow): include workflow_{url,file} as response

## Test Results

### Go TestRun

```bash
◆ functions git:(pick_build_trigger) ❯❯❯ export GITHUB_TOKEN=(gopass cat github-credentials/DAEBOT_GITHUB_TOKEN)                                                           21:59:23
◆ functions git:(pick_build_trigger) ❯❯❯ go test -v ./pkg/github/ -run TestWorkflow_TriggerDaedPickBuild                                                                   21:59:25
=== RUN   TestWorkflow_TriggerDaedPickBuild
204
--- PASS: TestWorkflow_TriggerDaedPickBuild (0.73s)
PASS
ok      daeuniverse/functions/pkg/github        0.731s
```

https://github.com/daeuniverse/daed/actions/runs/5917791112

<img width="1009" alt="image" src="https://github.com/daeuniverse/functions/assets/31861128/5987fe1e-fefc-484a-a44a-7b0f5f5d2595">

### API Trigger

```
/POST http://localhost:5888/api/v2/workflow?name=daed-pick-build&daed=main&wing=origin/main&dae=a319c955a598c02b54ae5d91e399ebed10c0fed4
```

<img width="825" alt="image" src="https://github.com/daeuniverse/functions/assets/31861128/98f336b7-4eb6-4442-81b5-df6f99b8fb10">
